### PR TITLE
Add accurate offline progress tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -1022,7 +1022,9 @@
         function saveGameState() {
             if (!cookiesAccepted) return;
 
-            // Existing game state save logic
+            // Mette à jour le timestamp avant de sauvegarder
+            lastSaveTime = Date.now();
+
             const gameState = {
                 hamburgers,
                 cookiePerClick,
@@ -1040,7 +1042,7 @@
                 clickCount,
                 clickUpgradeLevel,
                 buildingIdCounter,
-                lastSaveTime: Date.now()
+                lastSaveTime
             };
             localStorage.setItem('cookieGameSave', JSON.stringify(gameState));
         }
@@ -1670,7 +1672,24 @@
         }, 1000);
 
         setInterval(saveGameState, 10000);
-        window.addEventListener('beforeunload', saveGameState);
+        window.addEventListener('beforeunload', () => {
+            lastSaveTime = Date.now();
+            saveGameState();
+        });
+
+        document.addEventListener('visibilitychange', () => {
+            if (document.visibilityState === 'hidden') {
+                lastSaveTime = Date.now();
+                saveGameState();
+            } else if (document.visibilityState === 'visible') {
+                const elapsed = Math.floor((Date.now() - lastSaveTime) / 1000);
+                if (elapsed > 0) {
+                    computeOfflineProgress(elapsed);
+                    updateDisplay();
+                    saveGameState();
+                }
+            }
+        });
     </script>
 </body>
 


### PR DESCRIPTION
## Summary
- record `lastSaveTime` whenever game saves
- update timestamp when page is hidden or before unload
- apply offline burger production on return

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68751281d2d88321b0babd4f85266659